### PR TITLE
Update leftwm DESKTOP_SESSION tuple

### DIFF
--- a/usr/lib/arcologout/Functions.py
+++ b/usr/lib/arcologout/Functions.py
@@ -156,7 +156,7 @@ def _get_logout():
         return "pkill fvwm3"
     elif desktop in ("stumpwm", "/usr/bin/stumpwm"):
         return "pkill stumpwm"
-    elif desktop in ("leftwm", "/usr/bin/leftwm"):
+    elif desktop in ("leftwm", "/usr/share/xsessions/leftwm"):
         return "pkill leftwm"
     return None
 


### PR DESCRIPTION
Seeing NoneType errors on the logout function using leftwm & lightdm. Might be worth parsing the path to get the last item.
```
❯ uname -a && echo $DESKTOP_SESSION
Linux arco-desk 5.10.20-1-lts #1 SMP Thu, 04 Mar 2021 12:02:02 +0000 x86_64 GNU/Linux
/usr/share/xsessions/leftwm
```