### PR TITLE
Fix argument for lock function after i3lock update

### DIFF
--- a/etc/arcologout.conf
+++ b/etc/arcologout.conf
@@ -6,7 +6,7 @@ font_size=11
 buttons=cancel,logout,restart,shutdown,suspend,hibernate,lock
 
 [commands]
-lock=betterlockscreen -l dimblur -- --timestr="%H:%M"
+lock=betterlockscreen -l dimblur -- --time-str="%H:%M"
 
 # =======Themes=============
 

--- a/usr/share/arcologout/arcologout.py
+++ b/usr/share/arcologout/arcologout.py
@@ -24,7 +24,7 @@ class TransparentWindow(Gtk.Window):
     cmd_restart = "systemctl reboot"
     cmd_suspend = "systemctl suspend"
     cmd_hibernate = "systemctl hibernate"
-    cmd_lock = 'betterlockscreen -l dimblur -- --timestr="%H:%M"'
+    cmd_lock = 'betterlockscreen -l dimblur -- --time-str="%H:%M"'
     wallpaper = "/usr/share/arcologout/wallpaper.jpg"
     d_buttons = ['cancel',
                  'shutdown',


### PR DESCRIPTION
i3lock has been updated with a lot of arguments refactored to kebab-case so this is needed to get the lock function to actually work.