### PR TITLE
Let the user use any lock command.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,20 +1,23 @@
 # Maintainer: Ruslan Sergin <ruslan.sergin@gmail.com>
 #             Stevan Antoine (temporary)
-pkgname=arcolinux-logout
+pkgname=arcolinux-logout-a2n-s-git
 pkgver=22.03_12
 pkgrel=2
 pkgdesc="Beautiflul ArcoLinux logout screen"
-url="https://github.com/a2n-s/arcolinux-logout"
+url="https://github.com/a2n-s/arcolinux-logout.git"
 arch=('x86_64')
 depends=('python3' 'python-cairo')
+provides=(arcolinux-logout)
+conflicts=(arcolinux-logout)
 license=('GPL3')
-source=("$pkgname-$pkgver.tar.gz::https://github.com/a2n-s/arcolinux-logout/archive/refs/tags/${pkgver//_/-}.tar.gz#branch=lock/other")
+source=("git+$url#branch=lock/other")
 # md5sums=('23d72b9ccd59689b4c47c07b416a7344')
 md5sums=('SKIP')
 
 package () {
+    cd arcolinux-logout
     mkdir -p "${pkgdir}" 
-    mv "${srcdir}/${pkgname}-${pkgver//_/-}/"{usr,etc} "${pkgdir}/"
-    mv "${srcdir}/${pkgname}-${pkgver//_/-}/LICENSE" "${pkgdir}/usr/share/arcologout"
-    mv "${srcdir}/${pkgname}-${pkgver//_/-}/README.md" "${pkgdir}/usr/share/arcologout"
+    mv {usr,etc} "${pkgdir}/"
+    mv LICENSE "${pkgdir}/usr/share/arcologout"
+    mv README.md "${pkgdir}/usr/share/arcologout"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: Ruslan Sergin <ruslan.sergin@gmail.com>
+#             Stevan Antoine (temporary)
+pkgname=arcolinux-logout
+pkgver=22.03_12
+pkgrel=2
+pkgdesc="Beautiflul ArcoLinux logout screen"
+url="https://github.com/a2n-s/arcolinux-logout"
+arch=('x86_64')
+depends=('python3' 'python-cairo')
+license=('GPL3')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/a2n-s/arcolinux-logout/archive/refs/tags/${pkgver//_/-}.tar.gz#branch=lock/other")
+# md5sums=('23d72b9ccd59689b4c47c07b416a7344')
+md5sums=('SKIP')
+
+package () {
+    mkdir -p "${pkgdir}" 
+    mv "${srcdir}/${pkgname}-${pkgver//_/-}/"{usr,etc} "${pkgdir}/"
+    mv "${srcdir}/${pkgname}-${pkgver//_/-}/LICENSE" "${pkgdir}/usr/share/arcologout"
+    mv "${srcdir}/${pkgname}-${pkgver//_/-}/README.md" "${pkgdir}/usr/share/arcologout"
+}

--- a/usr/share/arcologout/arcologout.py
+++ b/usr/share/arcologout/arcologout.py
@@ -309,7 +309,7 @@ class TransparentWindow(Gtk.Window):
             Gtk.main_quit()
 
         elif (data == self.binds.get('lock')):
-            if not fn.os.path.isdir(fn.home + "/.cache/betterlockscreen"):
+            if self.cmd_lock.startswith("betterlockscreen") and not fn.os.path.isdir(fn.home + "/.cache/betterlockscreen"):
                 if fn.os.path.isfile(self.wallpaper):
                     self.lbl_stat.set_markup("<span size=\"x-large\"><b>Caching lockscreen images for a faster locking next time</b></span>")  # noqa
                     t = threading.Thread(target=fn.cache_bl,


### PR DESCRIPTION
When trying to use `slock` as a replacement for `betterlockscreen`, it did not work as the `arcologout.py` script expects `~/.cache/betterlockscreen` to exist.

This pull request allows the user to write something like `lock=slock -m "my lock message"` inside `~/.config/arcologout/arcologout.conf` by simply checking the existence of the `betterlockscreen`'s cache only when the command is `betterlockscreen`.

Hope this will make it to the final arcologout as it is a very pretty logout command! :wave: